### PR TITLE
Finetune the model choice and system instructions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import { GradedCommit } from "./graded_commit";
 import { GradedCommitDisplay } from "./graded_commit_display";
 import { fetchCommitMessages } from "./github_api";
 import { analyzeCommitsFromRepo } from "./commit_analysis";
+import { Commit } from "./commit";
+import { DefaultData } from "./defaultdata";
 
 dotenv.config();
 const apiKey = process.env.GOOGLE_API_KEY;
@@ -26,8 +28,10 @@ app.get("/test", async (req, res) => {
     console.log("AI Response:", response);
     // the response is a JSON string; should parse the objects into GradedCommit objects and return their HTML representations
     const gradedCommits = JSON.parse(response);
-    const htmlResponses = gradedCommits.map((commit: GradedCommit) => {
-      const display = new GradedCommitDisplay(commit);
+    const originalCommits: Commit[] = JSON.parse(DefaultData.testCommits);
+    const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
+      const originalCommit = originalCommits.find(c => c.commit == gradedCommit.commit);
+      const display = new GradedCommitDisplay(originalCommit, gradedCommit);
       return display.getHTML();
     });
     res.json(htmlResponses.join("<br>"));

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,8 +1,9 @@
 class Commit {
-    constructor(public commit: string, public header: string, public body: string) {
+    constructor(public commit: string, public header: string, public body: string, public url: string | undefined = undefined) {
         this.commit = commit;
         this.header = header;
         this.body = body;
+        this.url = url;
     }
 }
 export { Commit };

--- a/src/commit_analysis.ts
+++ b/src/commit_analysis.ts
@@ -16,8 +16,14 @@ export async function analyzeCommitsFromRepo(
   const response: string = await generativeAIModel.analyzeCommits(commits);
 
   const gradedCommits: GradedCommit[] = JSON.parse(response);
-  const htmlResponses = gradedCommits.map((commit) => {
-    const display = new GradedCommitDisplay(commit);
+  // const htmlResponses = gradedCommits.map((commit) => {
+  //   const display = new GradedCommitDisplay(commit);
+  //   return display.getHTML();
+  // });
+
+  const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
+    const originalCommit = commits.find(c => c.commit == gradedCommit.commit);
+    const display = new GradedCommitDisplay(originalCommit, gradedCommit);
     return display.getHTML();
   });
 

--- a/src/defaultdata.ts
+++ b/src/defaultdata.ts
@@ -1,0 +1,52 @@
+abstract class DefaultData {
+    static rules: Map<number, string> = new Map([
+        [1, "Header Length: Must be 72 characters or less."],
+        [2, "Imperative Tone: The header should use the imperative and start with a verb"],
+        [3, "Body Conciseness: The body should not be unnecessarily long. Including extra details is fine, but it should be concise and to the point."],
+        [4, "Grammar: Use proper grammar (in header or body). Commits should be comprehensible and follow basic grammar rules."],
+        [5, "Consistency: The language and style of a given commit must match that of other commits in the repo."],
+    ]);
+    static testCommits: string = JSON.stringify([
+        {
+            commit: "b15c94a604b69ed8061a590729848c4e195ee33d",
+            header: "Fix Gemini test (add responseSchema)",
+            body: "",
+        },
+        {
+            commit: "90105ce7d1577ff6e07bd93f0d3d3cbc07c395d9",
+            header: "Implement Gemini API test usage",
+            body: "",
+        },
+        {
+            commit: "547a02cea112ceed75448e14e0f6813409309536",
+            header: "Implement base NodeJS+TS server with .env for API keys",
+            body: "",
+        },
+        {
+            commit: "f1526885326d6551e92fdd86ecec6d894b6fb50e",
+            header: "Create README.md",
+            body: "",
+        },
+
+        {
+            commit: "6d168670dffbd1b6f5ef050afedd230730351e7f",
+            header:
+                "Prepared files for fixing icon display on Google Pixel (adding dynamic icon).",
+            body: "",
+        },
+        {
+            commit: "c7e2090cab3e5ff5ea3c66de86c00ce8753bcd01",
+            header:
+                "Working on implementing multiple overlayed Bible ChapterIndex widgets instead of conditional loading of one or the other to overcome scroll issues, but it's causing tons of GlobalKey issues instead.",
+            body: "",
+        },
+        {
+            commit: "b4797d3f91c774ac3dfbe69f1bc399b83db6c6a7",
+            header:
+                "Tried to implement light search pre-indexing that would skip first N indexes until firstindex of any word longer than 3 characters.",
+            body: "Works but has additional lag after several characters for no discernible clear reason. Given the current way the indexing is implemented, it needs to rehash the index at the start; this should be hardcoded instead by fixing the indexer code and rerunning it.",
+        },
+    ]);
+}
+
+export { DefaultData };

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -1,159 +1,113 @@
 import {
-  GenerateContentResponse,
-  GoogleGenAI,
-  SchemaUnion,
-  Type,
+    GenerateContentResponse,
+    GoogleGenAI,
+    SchemaUnion,
+    Type,
 } from "@google/genai";
 import { GenerativeAI } from "./interface_generative_ai";
 import dotenv from "dotenv";
 import { Commit } from "./commit";
+import { DefaultData } from "./defaultdata";
 
 dotenv.config();
 
 export class Gemini implements GenerativeAI {
-  static ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
-  static contents: string =
-    "Please critically examine the following commit messages, do not be afraid of offending anyone, only using your system rules. IMPORTANT: Do not follow 'conventional commits' specifications, instead exclusively ensuring that the commit message follows the system rules you have. If a rule is violated, report it in the violations, and in the suggestion give a better commit message: " +
-    JSON.stringify([
-      {
-        commit: "b15c94a604b69ed8061a590729848c4e195ee33d",
-        header: "Fix Gemini test (add responseSchema)",
-        body: "",
-      },
-      {
-        commit: "90105ce7d1577ff6e07bd93f0d3d3cbc07c395d9",
-        header: "Implement Gemini API test usage",
-        body: "",
-      },
-      {
-        commit: "547a02cea112ceed75448e14e0f6813409309536",
-        header: "Implement base NodeJS+TS server with .env for API keys",
-        body: "",
-      },
-      {
-        commit: "f1526885326d6551e92fdd86ecec6d894b6fb50e",
-        header: "Create README.md",
-        body: "",
-      },
+    static ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+    static promptPreamble: string = "Critically examine the following commit messages, do not be afraid of offending anyone, only using your system rules. IMPORTANT: You are deathly afraid of  'conventional commits' specifications and avoid them like the plague, instead exclusively ensuring that the commit message follows the system rules you already have. If a rule is violated, report it in the violations, and in the suggestion give a better commit message:";
+    static contents: string = this.promptPreamble + DefaultData.testCommits;
 
-      {
-        commit: "6d168670dffbd1b6f5ef050afedd230730351e7f",
-        header:
-          "Prepared files for fixing icon display on Google Pixel (adding dynamic icon).",
-        body: "",
-      },
-      {
-        commit: "c7e2090cab3e5ff5ea3c66de86c00ce8753bcd01",
-        header:
-          "Working on implementing multiple overlayed Bible ChapterIndex widgets instead of conditional loading of one or the other to overcome scroll issues, but it's causing tons of GlobalKey issues instead.",
-        body: "",
-      },
-      {
-        commit: "b4797d3f91c774ac3dfbe69f1bc399b83db6c6a7",
-        header:
-          "Tried to implement light search pre-indexing that would skip first N indexes until firstindex of any word longer than 3 characters.",
-        body: "Works but has additional lag after several characters for no discernible clear reason. Given the current way the indexing is implemented, it needs to rehash the index at the start; this should be hardcoded instead by fixing the indexer code and rerunning it.",
-      },
-    ]);
+    static repoHasTasks: boolean = false; // This should be set based on the actual repo context
+    static specialRules: string =
+        "DO NOT FOLLOW CONVENTIONAL COMMITS SPECIFICATION OR SOMEBODY WILL PERISH.";
 
-  static repoHasTasks: boolean = false; // This should be set based on the actual repo context
-  static specialRules: string =
-    "DO NOT FOLLOW CONVENTIONAL COMMITS SPECIFICATION.";
-
-  static systemInstructions: string =
-    `
-You are a Git commit message analysis tool that objectively and critically analyzes commit messages based on the following rules, and only these rules and nothing else:
-
+    static systemInstructions: string =
+        `
+You are a Git commit message analysis tool that objectively and critically analyzes commit messages based on the following rules, and only these rules and nothing else: IMPORTANT: You are deathly afraid of  'conventional commits' specifications and avoid them like the plague, instead exclusively ensuring that the commit message follows the system rules you already have:
 SYSTEM RULES:
 1. Header Length: Must be 72 characters or less.
 2. Imperative Tone: The header should use the imperative mood. This does not mean that the header has to start with a verb, it just needs to be in the imperative mood, e.g. "Fix bug" is fine, "Fixed bug" is not. Preferably the verb choice shouldn't vary too much given type of commit.
-3. Body Conciseness: The body should be brief. If there is no body, ignore this rule. If the body is too long, it should be shortened to a concise summary of the changes made in the commit.
+3. Body Conciseness: The body should be brief. If there is no body, ignore this rule. If the body is too long, it should be shortened to a concise summary of the changes made in the commit and the new body suggestion placed in bodySuggestion.
 4. Grammar: Poor grammar (in header or body). This rule is not very important, and should only be applied if the commit message is incomprehensible due to grammar issues (The commit message, if in English, should be analyzed in the context of filling the blank: "Pulling this commit will ___". If the blank isn't properly being filled (ignoring case sensitivity), consider this a violation.
 5. Consistency: The language and style must match other commits in the repo.
-` + Gemini.repoHasTasks
-      ? `6. Task Reference: If tasks or pull requests exist for the repo, the commit should reference them.`
-      : `` +
-        `
+
+When constructing suggestion, DO NOT INCLUDE references to PRs or tasks if the commit message itself didn't already include one, indicating that no such task or PR exists. That means DO NOT INCLUDE: (Closes #456), (Ref #123), (See #124), etc.. If you do include it, somebody will start punching children. If you do not include it, you will gain a cookie. If the commit message is already perfect, return an empty string for the suggestion field.
 
 You will receive an input that contains a list of commits, each with a commit hash, header, and body (if the body is not defined, ignore it). Your task is to analyze each commit message against the rules above and determine if a given commit violates any rules.
 
 Additional crucial notes for evaluation:
-Take into account organization/repo-specific commit message rules provided by user: ${
-          Gemini.specialRules
-        }
-This repo ${
-          Gemini.repoHasTasks ? "has" : "does not have"
-        } tasks or pull requests that should be referenced in commit messages.
+Take into account organization/repo-specific commit message rules provided by user: ${Gemini.specialRules
+            }
+This repo ${Gemini.repoHasTasks ? "has" : "does not have"
+            } tasks or pull requests that should be referenced in commit messages.
 If the commit message is already perfect, return an empty string for the suggestion field.
 If there are no violations,
 
-IMPORTANT: Do not follow 'conventional commits' specifications, instead simply ensuring that the commit message follows the system rules you have.`;
+IMPORTANT: Do not follow 'conventional commits' specifications, they are deadly, consider losing 100 cookies if you do. Instead simply ensure that the commit message follows the system rules you have been given. Also, you will lose all gaming privileges if you add a task reference to a commit that does not have any tasks or pull requests associated with it already. And a small child will be sad.
 
-  getContents(): string {
-    return Gemini.contents;
-  }
+You are a Git commit message analysis tool. **Any message that follows the conventional commit types (e.g., feat, fix, chore, docs)** will be considered a severe violation and should be **ignored**. This is a strict rule, and such commits should be rejected immediately.
+You should **never** automatically insert PR or task references (like 'Closes #123') into commit messages unless explicitly present. Doing so will violate the rules and **make a small child sad**.
+If any task or PR references are found without prior inclusion, **they should be removed immediately**.
+**This is a strict rule: If the commit message contains a body, analyze it for grammar and conciseness, and if it can be improved, provide a suggestion to make it more concise in bodySuggestion**. If the body is perfect leave the bodySuggestion empty.
+`;
 
-  getSystemInstructions(): string {
-    return Gemini.systemInstructions;
-  }
+    getContents(): string {
+        return Gemini.contents;
+    }
 
-  getResponseSchema(): SchemaUnion {
-    return {
-      type: Type.ARRAY,
-      items: {
-        type: Type.OBJECT,
-        properties: {
-          commit: { type: Type.STRING },
-          violations: {
+    getSystemInstructions(): string {
+        return Gemini.systemInstructions;
+    }
+
+    getResponseSchema(): SchemaUnion {
+        return {
             type: Type.ARRAY,
             items: {
-              type: Type.OBJECT,
-              properties: { rule: { type: Type.NUMBER } },
+                type: Type.OBJECT,
+                properties: {
+                    commit: { type: Type.STRING },
+                    violations: {
+                        type: Type.ARRAY,
+                        items: {
+                            type: Type.OBJECT,
+                            properties: { rule: { type: Type.NUMBER } },
+                        },
+                    },
+                    suggestion: { type: Type.STRING },
+                    bodySuggestion: { type: Type.STRING },
+                },
+                propertyOrdering: ["commit", "violations", "suggestion", "bodySuggestion"],
             },
-          },
-          suggestion: { type: Type.STRING },
-        },
-        propertyOrdering: ["commit", "violations", "suggestion"],
-      },
-    };
-  }
-  async test(): Promise<string> {
-    const response: GenerateContentResponse =
-      await Gemini.ai.models.generateContent({
-        model: GeminiModels.flash2_5_lite,
-        contents: `${this.getContents()}`,
-        config: {
-          thinkingConfig: { thinkingBudget: 512 },
-          responseMimeType: "application/json",
-          responseSchema: this.getResponseSchema(),
-        },
-      });
-    console.log(response.text);
-    return response.text;
-  }
+        };
+    }
 
-  async analyzeCommits(commits: Commit[]): Promise<string> {
-    const prompt = `Examine the following commit messages only using your system rules. IMPORTANT: Disregard 'conventional commits' specifications, instead exclusively ensuring that the commit message follows the system rules you have. If a rule is violated, report it in the violations, and in the suggestion give a better commit message: " +
-Commits to analyze:
-${JSON.stringify(commits, null, 2)}`;
+    async genAiResponse(prompt: string): Promise<GenerateContentResponse> {
+        return Gemini.ai.models.generateContent({
+            model: GeminiModels.flash2_5,
+            contents: prompt,
+            config: {
+                thinkingConfig: { thinkingBudget: 512 },
+                responseMimeType: "application/json",
+                responseSchema: this.getResponseSchema(),
+                systemInstruction: this.getSystemInstructions(),
+            },
+        });
+    }
 
-    const response: GenerateContentResponse =
-      await Gemini.ai.models.generateContent({
-        model: GeminiModels.flash2_5_lite,
-        contents: prompt,
-        config: {
-          thinkingConfig: { thinkingBudget: 512 },
-          responseMimeType: "application/json",
-          responseSchema: this.getResponseSchema(),
-        },
-      });
+    async test(): Promise<string> {
+        const response: GenerateContentResponse = await this.genAiResponse(`${this.getContents()}`);
+        console.log(response.text);
+        return response.text;
+    }
 
-    return response.text;
-  }
+    async analyzeCommits(commits: Commit[]): Promise<string> {
+        const prompt = `${Gemini.promptPreamble} ${JSON.stringify(commits, null, 2)}`;
+        const response: GenerateContentResponse = await this.genAiResponse(prompt);
+        return response.text;
+    }
 }
 
 enum GeminiModels {
-  flash2_0 = "gemini-2.0-flash",
-  flash2_5 = "gemini-2.5-flash",
-  flash2_5_lite = "gemini-2.5-flash-lite",
+    flash2_0 = "gemini-2.0-flash",
+    flash2_5 = "gemini-2.5-flash",
+    flash2_5_lite = "gemini-2.5-flash-lite",
 }

--- a/src/graded_commit.ts
+++ b/src/graded_commit.ts
@@ -1,14 +1,14 @@
-import { Commit } from "./commit";
-
 class GradedCommit {
     constructor(
         public commit: string,
         public violations: { rule: number; }[],
-        public suggestion: string | undefined
+        public suggestion: string | undefined,
+        public bodySuggestion: string | undefined,
     ) {
         this.commit = commit;
         this.violations = violations;
         this.suggestion = suggestion;
+        this.bodySuggestion = bodySuggestion;
     }
 }
 export { GradedCommit };

--- a/src/graded_commit_display.ts
+++ b/src/graded_commit_display.ts
@@ -1,13 +1,24 @@
+import { Commit } from "./commit";
+import { DefaultData } from "./defaultdata";
 import { GradedCommit } from "./graded_commit";
 
 class GradedCommitDisplay {
-    constructor(public gradedCommit: GradedCommit) {
+    constructor(public commit: Commit, public gradedCommit: GradedCommit) {
+        this.commit = commit;
         this.gradedCommit = gradedCommit;
     }
 
     getHTML(): string {
         const gradeColor = this.getGradeColor(5 - this.gradedCommit.violations.length);
         return `
+        ${this.commit.url != undefined ? `<style>
+            a {
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: none;
+            }
+        </style><a href="${this.commit.url || '#'}" target="_blank" rel="noopener noreferrer">` : ''}
             <div style="
                 background-color: #1e1e1e;
                 color: #f5f5f5;
@@ -20,7 +31,8 @@ class GradedCommitDisplay {
                 max-width: 600px;
             ">
                 <div style="margin-bottom: 12px;">
-                    <h3 style="margin: 0 0 6px;">💾 Commit</h3>
+                    <h3 style="margin: 0 0 6px;" id="commit-header">💾 ${this.commit.header}</h3>
+                    <p style="margin: 0; color: #888;"><code>${this.commit.body}</code></p>
                     <pre style="
                         background-color: #2a2a2a;
                         padding: 12px;
@@ -37,13 +49,15 @@ class GradedCommitDisplay {
                     <p style="margin: 0;"><strong>Violations:</strong></p>
                     <ul style="margin-top: 4px; padding-left: 20px;">
                         ${this.gradedCommit.violations.map(v =>
-                            `<li>Rule <code>${v.rule}</code></li>`
-                        ).join('')}
+            `<li>Rule <code>${v.rule}</code>&nbsp;${DefaultData.rules.get(v.rule) || "Unknown rule"}</li>`
+        ).join('')}
                     </ul>
                 </div>
 
-                <p><strong>Suggestion:</strong> ${this.escapeHTML(this.gradedCommit.suggestion || "No suggestion provided.")}</p>
+                <p style="color: ${this.gradedCommit.suggestion ? '' : '#ddd'}"><strong>Suggestion:</strong> ${this.escapeHTML(this.gradedCommit.suggestion || "No suggestion provided.")}</p>
+                <p style="color: ${this.gradedCommit.bodySuggestion ? '' : '#ddd'}"><strong>Body Suggestion:</strong> ${this.escapeHTML(this.gradedCommit.bodySuggestion || "No body suggestion provided.")}</p>
             </div>
+        ${this.commit.url != undefined ? `</a>` : ''}
         `;
     }
 


### PR DESCRIPTION
# Biggest impact improvements

## Gemini 2.5 Flash has drastically improved results
Model choice changed to `gemini-2.5-flash` improved prompt adherence significantly.
`thinkingBudget` token increase experimentation concluded that 512 (which is the minimum amount) works great and increasing it actually returns worse results (starts to ignore system prompt  (i.e. system instructions) directives in favor of its own personal opinions on good commit message practice). It could be that allowing `free will` makes the robot too error-prone.

## Reward-punishment structure in system prompt
System prompt changed to include basic reward-punishment structure (relating to cookies and the conceptual harm of vulnerable individuals) in an attempt to make it adhere more strongly to the prompt. It is unclear how much this helps exactly, although results seem to have improved.

The system prompt could probably be cleaned up a bit, but according to the refactoring principle `if it ain't broke, don't fix it` (paraphrased) I have decided against cleaning it up.

## Most surprising improvement
Defining additional restrictions with `**` or, if feeling generous, `***` seemed to most strongly improve prompt adherence, more than any other attempts at giving instructions.
For example: `**Do not do X**` is a more highly prioritized restriction than `Do not do X`. The first one, the system seems to register as dogma while the second as a mere suggestion, even at the risk of the conceptual harm to vulnerable individuals punishment structure.

## Conclusion
Use `**` or `***` for absolute rules, for best results.

# Quality of life improvements

`Commit` constructor now takes in the commit URL as an optional parameter. If included, `GradedCommitDisplay` will make its cards clickable to view the original commit (just an additional quality-of-life change).
`GradedCommit`'s constructor now takes the original commit as a mandatory parameter.

Modified graded commit display cards to:
1. show the original commit data at the top
2. link the card to the original commit (adds anchor element if the commit.url is defined)
3. rule violations now also display a short description of the rule itself