### PR TITLE
Commit filtering

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,9 @@ app.get("/test", async (req, res) => {
     const gradedCommits = JSON.parse(response);
     const originalCommits: Commit[] = JSON.parse(DefaultData.testCommits);
     const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
-      const originalCommit = originalCommits.find(c => c.commit == gradedCommit.commit);
+      const originalCommit = originalCommits.find(
+        (c) => c.commitHash == gradedCommit.commitHash
+      );
       const display = new GradedCommitDisplay(originalCommit, gradedCommit);
       return display.getHTML();
     });

--- a/src/app.ts
+++ b/src/app.ts
@@ -109,6 +109,11 @@ Instructions: <span style="color: #0ff;">${generativeAIModel.getContents()}</spa
 
 app.get("/fetch-commits", async (req, res) => {
   const repoUrl = req.query.repoUrl as string;
+  const branch = req.query.branch as string;
+  const author = req.query.author as string;
+  const perPage = req.query.perPage
+    ? parseInt(req.query.perPage as string, 10)
+    : undefined;
 
   if (!repoUrl) {
     return res.status(400).json({ error: "Missing repoUrl parameter" });
@@ -120,7 +125,13 @@ app.get("/fetch-commits", async (req, res) => {
   }
 
   try {
-    const commitMessages = await fetchCommitMessages(repoUrl, githubToken);
+    const commitMessages = await fetchCommitMessages(
+      repoUrl,
+      githubToken,
+      branch,
+      author,
+      perPage
+    );
     res.json({ commits: commitMessages });
   } catch (error: any) {
     res.status(500).json({ error: error.message });
@@ -129,6 +140,11 @@ app.get("/fetch-commits", async (req, res) => {
 
 app.get("/analyze-commits", async (req, res) => {
   const repoUrl = req.query.repoUrl as string;
+  const branch = req.query.branch as string | undefined;
+  const author = req.query.author as string | undefined;
+  const perPage = req.query.perPage
+    ? parseInt(req.query.perPage as string, 10)
+    : undefined;
 
   if (!repoUrl) {
     return res.status(400).json({ error: "Missing repoUrl parameter" });
@@ -143,7 +159,10 @@ app.get("/analyze-commits", async (req, res) => {
     const html = await analyzeCommitsFromRepo(
       repoUrl,
       githubToken,
-      generativeAIModel
+      generativeAIModel,
+      branch,
+      author,
+      perPage
     );
     res.send(html);
   } catch (error: any) {

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,9 +1,22 @@
 class Commit {
-    constructor(public commit: string, public header: string, public body: string, public url: string | undefined = undefined) {
-        this.commit = commit;
-        this.header = header;
-        this.body = body;
-        this.url = url;
-    }
+  constructor(
+    public commit: string,
+    public header: string,
+    public body: string,
+    public url: string,
+    public authorName: string,
+    public branch: string,
+    public repoHasOpenTasks: boolean,
+    public referencedTasks: string[] = []
+  ) {
+    this.commit = commit;
+    this.header = header;
+    this.body = body;
+    this.url = url;
+    this.authorName = authorName;
+    this.branch = branch;
+    this.repoHasOpenTasks = repoHasOpenTasks;
+    this.referencedTasks = referencedTasks;
+  }
 }
 export { Commit };

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,6 +1,6 @@
 class Commit {
   constructor(
-    public commit: string,
+    public commitHash: string,
     public header: string,
     public body: string,
     public url: string,
@@ -9,7 +9,7 @@ class Commit {
     public repoHasOpenTasks: boolean,
     public referencedTasks: string[] = []
   ) {
-    this.commit = commit;
+    this.commitHash = commitHash;
     this.header = header;
     this.body = body;
     this.url = url;

--- a/src/commit_analysis.ts
+++ b/src/commit_analysis.ts
@@ -1,4 +1,3 @@
-// commit_analysis.ts
 import { fetchCommitMessages } from "./github_api";
 import { GenerativeAI } from "./interface_generative_ai";
 import { GradedCommit } from "./graded_commit";
@@ -15,10 +14,6 @@ export async function analyzeCommitsFromRepo(
   const response: string = await generativeAIModel.analyzeCommits(commits);
 
   const gradedCommits: GradedCommit[] = JSON.parse(response);
-  // const htmlResponses = gradedCommits.map((commit) => {
-  //   const display = new GradedCommitDisplay(commit);
-  //   return display.getHTML();
-  // });
 
   const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
     const originalCommit = commits.find((c) => c.commit == gradedCommit.commit);

--- a/src/commit_analysis.ts
+++ b/src/commit_analysis.ts
@@ -16,7 +16,10 @@ export async function analyzeCommitsFromRepo(
   const gradedCommits: GradedCommit[] = JSON.parse(response);
 
   const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
-    const originalCommit = commits.find((c) => c.commit == gradedCommit.commit);
+    const originalCommit = commits.find(
+      (c) => c.commitHash == gradedCommit.commitHash
+    );
+
     const display = new GradedCommitDisplay(originalCommit, gradedCommit);
     return display.getHTML();
   });

--- a/src/commit_analysis.ts
+++ b/src/commit_analysis.ts
@@ -7,20 +7,30 @@ import { Commit } from "./commit";
 export async function analyzeCommitsFromRepo(
   repoUrl: string,
   githubToken: string,
-  generativeAIModel: GenerativeAI
+  generativeAIModel: GenerativeAI,
+  branch?: string,
+  author?: string,
+  perPage?: number
 ): Promise<string> {
-  const commits: Commit[] = await fetchCommitMessages(repoUrl, githubToken);
+  const commits: Commit[] = await fetchCommitMessages(
+    repoUrl,
+    githubToken,
+    branch,
+    author,
+    perPage
+  );
 
   const response: string = await generativeAIModel.analyzeCommits(commits);
 
   const gradedCommits: GradedCommit[] = JSON.parse(response);
 
   const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
-    const originalCommit = commits.find(
-      (c) => c.commitHash == gradedCommit.commitHash
-    );
+    const originalCommit = commits.find((c) => {
+      return c.commitHash === gradedCommit.commitHash;
+    });
 
     const display = new GradedCommitDisplay(originalCommit, gradedCommit);
+
     return display.getHTML();
   });
 

--- a/src/commit_analysis.ts
+++ b/src/commit_analysis.ts
@@ -12,7 +12,6 @@ export async function analyzeCommitsFromRepo(
 ): Promise<string> {
   const commits: Commit[] = await fetchCommitMessages(repoUrl, githubToken);
 
-  // @ts-ignore - generativeAIModel has analyzeCommits
   const response: string = await generativeAIModel.analyzeCommits(commits);
 
   const gradedCommits: GradedCommit[] = JSON.parse(response);
@@ -22,7 +21,7 @@ export async function analyzeCommitsFromRepo(
   // });
 
   const htmlResponses = gradedCommits.map((gradedCommit: GradedCommit) => {
-    const originalCommit = commits.find(c => c.commit == gradedCommit.commit);
+    const originalCommit = commits.find((c) => c.commit == gradedCommit.commit);
     const display = new GradedCommitDisplay(originalCommit, gradedCommit);
     return display.getHTML();
   });

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -66,7 +66,7 @@ If any task or PR references are found without prior inclusion, **they should be
       items: {
         type: Type.OBJECT,
         properties: {
-          commit: { type: Type.STRING },
+          commitHash: { type: Type.STRING },
           violations: {
             type: Type.ARRAY,
             items: {
@@ -78,7 +78,7 @@ If any task or PR references are found without prior inclusion, **they should be
           bodySuggestion: { type: Type.STRING },
         },
         propertyOrdering: [
-          "commit",
+          "commitHash",
           "violations",
           "suggestion",
           "bodySuggestion",

--- a/src/github_api.ts
+++ b/src/github_api.ts
@@ -9,10 +9,6 @@ function parseRepoUrl(repoUrl: string) {
   return { owner: match[1], repo: match[2] };
 }
 
-/**
- * Fetch commits from GitHub API.
- * Returns array of Commit objects (hash, header, body).
- */
 export async function fetchCommitMessages(
   repoUrl: string,
   githubToken: string
@@ -20,14 +16,40 @@ export async function fetchCommitMessages(
   const { owner, repo } = parseRepoUrl(repoUrl);
 
   try {
-    const commitsUrl = `https://api.github.com/repos/${owner}/${repo}/commits`;
+    // Get repo details for default branch
+    const repoInfo = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      {
+        headers: {
+          Authorization: `token ${githubToken}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+      }
+    );
+    const defaultBranch = repoInfo.data.default_branch || "main";
 
+    // Get open issues/tasks
+    const issuesRes = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/issues`,
+      {
+        headers: {
+          Authorization: `token ${githubToken}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+        params: { state: "open", per_page: 100 },
+      }
+    );
+    const issueNumbers = issuesRes.data.map((issue: any) => issue.number);
+    const repoHasOpenTasks = issueNumbers.length > 0;
+
+    // Get recent commits
+    const commitsUrl = `https://api.github.com/repos/${owner}/${repo}/commits`;
     const response = await axios.get(commitsUrl, {
       headers: {
         Authorization: `token ${githubToken}`,
         Accept: "application/vnd.github.v3+json",
       },
-      params: { per_page: 20 },
+      params: { per_page: 20, sha: defaultBranch }, // limit & branch filter
     });
 
     return response.data.map((commitObj: any) => {
@@ -35,8 +57,38 @@ export async function fetchCommitMessages(
       const fullMessage = commitObj.commit.message;
       const [header, ...bodyLines] = fullMessage.split("\n");
       const body = bodyLines.join("\n").trim();
+      const authorName =
+        commitObj.commit.author?.name || commitObj.author?.login || "Unknown";
 
-      return new Commit(commitHash, header, body, commitObj.html_url);
+      // Find all issue/PR references as full links or number #123
+      const referencedTasks: string[] = [];
+      const taskRegex =
+        /#(\d+)|https:\/\/github\.com\/[^\/]+\/[^\/]+\/(issues|pull)\/(\d+)/g;
+
+      let match;
+      while ((match = taskRegex.exec(fullMessage)) !== null) {
+        if (match[0].startsWith("#")) {
+          // Convert #123 into full repo URL
+          referencedTasks.push(
+            `https://github.com/${owner}/${repo}/issues/${match[1]}`
+          );
+        } else {
+          referencedTasks.push(match[0]);
+        }
+      }
+
+      let c = new Commit(
+        commitHash,
+        header,
+        body,
+        commitObj.html_url,
+        authorName,
+        defaultBranch,
+        repoHasOpenTasks,
+        referencedTasks
+      );
+
+      return c;
     });
   } catch (error: any) {
     if (error.response?.status === 404) {
@@ -44,33 +96,6 @@ export async function fetchCommitMessages(
         "Access forbidden, check if the repository is public or if the URL is correct."
       );
     }
-    throw new Error(`GitHub API error: ${error.message}`);
-  }
-}
-
-export async function fetchCommitMessage(
-  repoUrl: string,
-  commitHash: string,
-  githubToken: string
-): Promise<Commit> {
-  const { owner, repo } = parseRepoUrl(repoUrl);
-
-  try {
-    const commitUrl = `https://api.github.com/repos/${owner}/${repo}/commits/${commitHash}`;
-
-    const response = await axios.get(commitUrl, {
-      headers: {
-        Authorization: `token ${githubToken}`,
-        Accept: "application/vnd.github.v3+json",
-      },
-    });
-
-    const fullMessage = response.data.commit.message;
-    const [header, ...bodyLines] = fullMessage.split("\n");
-    const body = bodyLines.join("\n").trim();
-
-    return new Commit(commitHash, header, body);
-  } catch (error: any) {
     throw new Error(`GitHub API error: ${error.message}`);
   }
 }

--- a/src/graded_commit.ts
+++ b/src/graded_commit.ts
@@ -1,14 +1,14 @@
 class GradedCommit {
-    constructor(
-        public commit: string,
-        public violations: { rule: number; }[],
-        public suggestion: string | undefined,
-        public bodySuggestion: string | undefined,
-    ) {
-        this.commit = commit;
-        this.violations = violations;
-        this.suggestion = suggestion;
-        this.bodySuggestion = bodySuggestion;
-    }
+  constructor(
+    public commitHash: string,
+    public violations: { rule: number }[],
+    public suggestion: string | undefined,
+    public bodySuggestion: string | undefined
+  ) {
+    this.commitHash = commitHash;
+    this.violations = violations;
+    this.suggestion = suggestion;
+    this.bodySuggestion = bodySuggestion;
+  }
 }
 export { GradedCommit };

--- a/src/graded_commit_display.ts
+++ b/src/graded_commit_display.ts
@@ -3,22 +3,30 @@ import { DefaultData } from "./defaultdata";
 import { GradedCommit } from "./graded_commit";
 
 class GradedCommitDisplay {
-    constructor(public commit: Commit, public gradedCommit: GradedCommit) {
-        this.commit = commit;
-        this.gradedCommit = gradedCommit;
-    }
+  constructor(public commit: Commit, public gradedCommit: GradedCommit) {
+    this.commit = commit;
+    this.gradedCommit = gradedCommit;
+  }
 
-    getHTML(): string {
-        const gradeColor = this.getGradeColor(5 - this.gradedCommit.violations.length);
-        return `
-        ${this.commit.url != undefined ? `<style>
+  getHTML(): string {
+    const gradeColor = this.getGradeColor(
+      5 - this.gradedCommit.violations.length
+    );
+    return `
+        ${
+          this.commit.url != undefined
+            ? `<style>
             a {
                 text-decoration: none;
             }
             a:hover {
                 text-decoration: none;
             }
-        </style><a href="${this.commit.url || '#'}" target="_blank" rel="noopener noreferrer">` : ''}
+        </style><a href="${
+          this.commit.url || "#"
+        }" target="_blank" rel="noopener noreferrer">`
+            : ""
+        }
             <div style="
                 background-color: #1e1e1e;
                 color: #f5f5f5;
@@ -31,8 +39,12 @@ class GradedCommitDisplay {
                 max-width: 600px;
             ">
                 <div style="margin-bottom: 12px;">
-                    <h3 style="margin: 0 0 6px;" id="commit-header">💾 ${this.commit.header}</h3>
-                    <p style="margin: 0; color: #888;"><code>${this.commit.body}</code></p>
+                    <h3 style="margin: 0 0 6px;" id="commit-header">💾 ${
+                      this.commit.header
+                    }</h3>
+                    <p style="margin: 0; color: #888;"><code>${
+                      this.commit.body
+                    }</code></p>
                     <pre style="
                         background-color: #2a2a2a;
                         padding: 12px;
@@ -40,51 +52,79 @@ class GradedCommitDisplay {
                         white-space: pre-wrap;
                         font-family: monospace;
                         overflow-x: auto;
-                    ">${this.escapeHTML(this.gradedCommit.commit)}</pre>
+                    ">${this.escapeHTML(this.gradedCommit.commitHash)}</pre>
                 </div>
 
-                <p><strong>Grade:</strong> <span style="color: ${gradeColor}; font-weight: bold;">${5 - this.gradedCommit.violations.length}</span></p>
+                <p><strong>Grade:</strong> <span style="color: ${gradeColor}; font-weight: bold;">${
+      5 - this.gradedCommit.violations.length
+    }</span></p>
 
                 <div style="margin: 8px 0;">
                     <p style="margin: 0;"><strong>Violations:</strong></p>
                     <ul style="margin-top: 4px; padding-left: 20px;">
-                        ${this.gradedCommit.violations.map(v =>
-            `<li>Rule <code>${v.rule}</code>&nbsp;${DefaultData.rules.get(v.rule) || "Unknown rule"}</li>`
-        ).join('')}
+                        ${this.gradedCommit.violations
+                          .map(
+                            (v) =>
+                              `<li>Rule <code>${v.rule}</code>&nbsp;${
+                                DefaultData.rules.get(v.rule) || "Unknown rule"
+                              }</li>`
+                          )
+                          .join("")}
                     </ul>
                 </div>
 
-                <p style="color: ${this.gradedCommit.suggestion ? '' : '#ddd'}"><strong>Suggestion:</strong> ${this.escapeHTML(this.gradedCommit.suggestion || "No suggestion provided.")}</p>
-                <p style="color: ${this.gradedCommit.bodySuggestion ? '' : '#ddd'}"><strong>Body Suggestion:</strong> ${this.escapeHTML(this.gradedCommit.bodySuggestion || "No body suggestion provided.")}</p>
+                <p style="color: ${
+                  this.gradedCommit.suggestion ? "" : "#ddd"
+                }"><strong>Suggestion:</strong> ${this.escapeHTML(
+      this.gradedCommit.suggestion || "No suggestion provided."
+    )}</p>
+                <p style="color: ${
+                  this.gradedCommit.bodySuggestion ? "" : "#ddd"
+                }"><strong>Body Suggestion:</strong> ${this.escapeHTML(
+      this.gradedCommit.bodySuggestion || "No body suggestion provided."
+    )}</p>
             </div>
-        ${this.commit.url != undefined ? `</a>` : ''}
+        ${this.commit.url != undefined ? `</a>` : ""}
         `;
-    }
+  }
 
-    private getGradeColor(grade: number): string {
-        switch (grade) {
-            case 0: return 'red';
-            case 1: return 'orange';
-            case 2: return 'yellow';
-            case 3: return 'green';
-            case 4: return 'blue';
-            case 5: return 'purple';
-            default: return 'gray';
-        }
+  private getGradeColor(grade: number): string {
+    switch (grade) {
+      case 0:
+        return "red";
+      case 1:
+        return "orange";
+      case 2:
+        return "yellow";
+      case 3:
+        return "green";
+      case 4:
+        return "blue";
+      case 5:
+        return "purple";
+      default:
+        return "gray";
     }
+  }
 
-    private escapeHTML(input: string): string {
-        return input.replace(/[&<>"']/g, function (match) {
-            switch (match) {
-                case "&": return "&amp;";
-                case "<": return "&lt;";
-                case ">": return "&gt;";
-                case "\"": return "&quot;";
-                case "'": return "&#039;";
-                default: return match;
-            }
-        });
-    }
+  private escapeHTML(input: string): string {
+    return input.replace(/[&<>"']/g, function (match) {
+      switch (match) {
+        case "&":
+          return "&amp;";
+        case "<":
+          return "&lt;";
+        case ">":
+          return "&gt;";
+        case '"':
+          return "&quot;";
+        case "'":
+          return "&#039;";
+        default:
+          return match;
+      }
+    });
+  }
 }
 
 export { GradedCommitDisplay };

--- a/src/interface_generative_ai.ts
+++ b/src/interface_generative_ai.ts
@@ -1,4 +1,7 @@
+import { Commit } from "./commit";
+
 export interface GenerativeAI {
-    test(): Promise<string>;
-    getContents(): string;
+  test(): Promise<string>;
+  getContents(): string;
+  analyzeCommits(commits: Commit[]): Promise<string>;
 }


### PR DESCRIPTION
- Expanded commit info (referenced tasks URLs if the commit has any referenced, commit author, commit branch)
- Filtering in URL params by `author, branch, perPage` (number of most recent commits desired) for both fetch and analyze endpoints. E.g.:
```
http://localhost:3066/fetch-commits?repoUrl=name&author=name&branch=name&perPage=2
http://localhost:3066/analyze-commits?repoUrl=name&author=name&branch=name&perPage=2
```
All params except `repoUrl` are optional.

- Added info about whether the repo has any open tasks so that the model knows (boolean param in Gemini -> see how will this influence the prompt/response)
