### PR TITLE
Add simple view (overall comment on all commits added to the top of the extension sidebar)

### DIFF
--- a/commitment-issues-extension/src/backend/src/ai/gemini.ts
+++ b/commitment-issues-extension/src/backend/src/ai/gemini.ts
@@ -10,9 +10,7 @@ import { Commit } from "../models/commit";
 import { DefaultData } from "./defaultdata";
 import { ConfigurationManager } from "../../../settings";
 
-
 export class Gemini implements GenerativeAI {
-
   static promptPreamble: string =
     "Critically examine the following commit messages, do not be afraid of offending anyone, only using your system rules. If a rule is violated, report it in the violations, and in the suggestion give a better commit message:";
   static contents: string = this.promptPreamble + DefaultData.testCommits;
@@ -33,7 +31,9 @@ When constructing a suggestion, DO NOT INCLUDE references to PRs or tasks if the
 You will receive an input that contains a list of commits, each with a commit hash, header, and body (if the body is not defined, ignore it). Your task is to analyze each commit message against the rules above and determine if a given commit violates any rules.
 
 Additional crucial notes for evaluation:
-*This repo ${Gemini.repoHasOpenTasks ? "has" : "does not have"} tasks or pull requests that should be referenced in commit messages.*
+*This repo ${
+    Gemini.repoHasOpenTasks ? "has" : "does not have"
+  } tasks or pull requests that should be referenced in commit messages.*
 If the commit message is already perfect, return an empty string for the suggestion field.
 If there are no violations,
 
@@ -52,12 +52,15 @@ If any task or PR references are found without prior inclusion, **they should be
   }
 
   getSpecialRules(): string {
-    return ConfigurationManager.specialRules ?
-`Special rules provided by the user, of utmost importance: ***These rules can override system rules: ${ConfigurationManager.specialRules}***` : "";
+    return ConfigurationManager.specialRules
+      ? `Special rules provided by the user, of utmost importance: ***These rules can override system rules: ${ConfigurationManager.specialRules}***`
+      : "";
   }
 
   getSystemInstructions(): string {
-    return ConfigurationManager.specialRulesOverrideSystemInstructions ? "" : Gemini.systemInstructions;
+    return ConfigurationManager.specialRulesOverrideSystemInstructions
+      ? ""
+      : Gemini.systemInstructions;
   }
 
   getResponseSchema(): SchemaUnion {
@@ -116,7 +119,8 @@ If any task or PR references are found without prior inclusion, **they should be
 
     commits.forEach((commit) => {
       if (commit.header.length > 72) {
-        commit.header = commit.header.substring(0, 72) + "|72|" + commit.header.substring(72);
+        commit.header =
+          commit.header.substring(0, 72) + "|72|" + commit.header.substring(72);
       }
     });
 
@@ -127,6 +131,42 @@ If any task or PR references are found without prior inclusion, **they should be
     )}`;
     const response: GenerateContentResponse = await this.genAiResponse(prompt);
     return response.text ?? "<no response>";
+  }
+
+  async generateStyleComment(
+    commits: Commit[],
+    author?: string
+  ): Promise<string> {
+    const ai = new GoogleGenAI({ apiKey: ConfigurationManager.gemini });
+
+    // keep the sample short so it’s cheap/stable
+    const sample = commits.slice(0, 50).map((c) => ({
+      header: c.header,
+      body: c.body?.slice(0, 160) ?? "",
+    }));
+
+    const stylePrompt = `You are an expert mentor for software engineering students.
+Given the following commit messages (headers + short bodies), write a short, personalized
+overall comment on the author's general commit-message writing style (NOT specific to any single commit).
+Keep it brief (3–5 sentences). Mention 1–2 strengths, 1–2 weaknesses, and finish with 3 concrete tips.
+Do NOT output JSON; return plain text only.${
+      author ? ` Address the author by name: ${author}.` : ""
+    }
+
+COMMITS:
+${JSON.stringify(sample, null, 2)}`;
+
+    const resp: GenerateContentResponse = await ai.models.generateContent({
+      model: GeminiModels.flash2_5,
+      contents: stylePrompt,
+      // IMPORTANT: no responseSchema here; ask for plain text
+      config: {
+        responseMimeType: "text/plain",
+        systemInstruction: "", // keep it neutral for this secondary call
+      },
+    });
+
+    return resp.text ?? "<no style comment>";
   }
 }
 

--- a/commitment-issues-extension/src/backend/src/app.ts
+++ b/commitment-issues-extension/src/backend/src/app.ts
@@ -106,8 +106,7 @@ function backend(): Server {
       }
 
       console.log("[/style-comment] Building violation stats...");
-      const { stats, avg, anyBelow3, total } =
-        buildViolationStats(lastAnalysis);
+      const { stats, avg, anyBelow3, total } = buildViolationStats(lastAnalysis);
 
       console.log(
         "[/style-comment] Stats built:",
@@ -125,6 +124,7 @@ function backend(): Server {
         return res.json({
           styleComment:
             "The commit messages analyzed are exceptionally good. We have found no notable commitment issues.",
+          avg: avg,
           stats,
         });
       }
@@ -136,7 +136,7 @@ function backend(): Server {
 
       console.log("[/style-comment] Gemini response:", comment);
 
-      return res.json({ styleComment: comment, stats });
+      return res.json({ styleComment: comment, avg: avg, stats });
     } catch (error: any) {
       console.error("[/style-comment] ERROR:", error);
       return res.status(500).json({ error: error.message || String(error) });

--- a/commitment-issues-extension/src/backend/src/presentation/graded_commit_display.ts
+++ b/commitment-issues-extension/src/backend/src/presentation/graded_commit_display.ts
@@ -20,6 +20,8 @@ class GradedCommitDisplay {
     // header length greater than 72 is a strict and objective violation, a cruel rule
     if (this.commit.header.length > 72) {
       if (!this.gradedCommit.violations.some(v => v.rule === 1)) this.gradedCommit.violations.push({ rule: 1 });
+    } else { // if the commit header length is not greater than 72; remove the violation
+      this.gradedCommit.violations = this.gradedCommit.violations.filter(v => v.rule !== 1);
     }
 
     // body suggestion drastically reduces body length, so the original body must not have been concise enough

--- a/commitment-issues-extension/src/extension.ts
+++ b/commitment-issues-extension/src/extension.ts
@@ -1,90 +1,169 @@
-import * as vscode from 'vscode';
-import { backend } from './backend/src/app';
-import { Server } from 'http';
-import { AnalysisResultsProvider } from './frontend/analysis_tree/data/analysis_results_data_provider';
-import { ConfigurationManager } from './settings';
+import * as vscode from "vscode";
+import { backend } from "./backend/src/app";
+import { Server } from "http";
+import { AnalysisResultsProvider } from "./frontend/analysis_tree/data/analysis_results_data_provider";
+import { ConfigurationManager } from "./settings";
 export enum VSCodeExtensionViews {
-    COMMIT_MESSAGES = "commits-list",
-    ANALYZED_COMMIT_MESSAGES = "analyzed-commits-list",
-    ROOT_COMMIT_ANALYSIS_RESULTS = "commitment-issues-analyze-view"
+  COMMIT_MESSAGES = "commits-list",
+  ANALYZED_COMMIT_MESSAGES = "analyzed-commits-list",
+  ROOT_COMMIT_ANALYSIS_RESULTS = "commitment-issues-analyze-view",
 }
 var _backendServer: Server | undefined;
 export function activate(context: vscode.ExtensionContext) {
+  // --- Create Output Channel for backend logs
+  const backendOut = vscode.window.createOutputChannel(
+    "Commitment Issues Backend"
+  );
+  backendOut.show(true); // or comment out if you don't want it to pop up
 
-	_backendServer = backend();
-	console.log("Commitment Issues extension active. Thank you for installing our extension! -Noa and Joshua.");
+  // --- Mirror console.* to Output Channel (keep originals)
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origErr = console.error;
 
-	const commitAnalysisProvider = new AnalysisResultsProvider(context);
-	vscode.window.registerTreeDataProvider(VSCodeExtensionViews.ROOT_COMMIT_ANALYSIS_RESULTS, commitAnalysisProvider);
+  const toLine = (...args: any[]) =>
+    args
+      .map((a) => {
+        try {
+          if (typeof a === "string") return a;
+          return JSON.stringify(a, null, 2);
+        } catch {
+          return String(a);
+        }
+      })
+      .join(" ");
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("commitment-issues.openConfig", () => {
-			vscode.commands.executeCommand("workbench.action.openSettings", "Commitment Issues config");
-		})
-	);
+  console.log = (...args: any[]) => {
+    origLog(...args);
+    backendOut.appendLine(
+      `[LOG ${new Date().toISOString()}] ${toLine(...args)}`
+    );
+  };
+  console.warn = (...args: any[]) => {
+    origWarn(...args);
+    backendOut.appendLine(
+      `[WARN ${new Date().toISOString()}] ${toLine(...args)}`
+    );
+  };
+  console.error = (...args: any[]) => {
+    origErr(...args);
+    backendOut.appendLine(
+      `[ERROR ${new Date().toISOString()}] ${toLine(...args)}`
+    );
+  };
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("commitment-issues.analyzeCommitMessages", async () => {
-			vscode.window.withProgress({
-				location: vscode.ProgressLocation.Notification,
-				title: `Analyzing ${ConfigurationManager.amount} commits on ${ConfigurationManager.branch}...`,
-				cancellable: false
-			}, async (progress) => {
-				await commitAnalysisProvider.analyze();
-				vscode.window.showInformationMessage("Analysis complete!");
-			});
-		})
-	);
+  // --- Catch uncaught errors from backend code too
+  process.on("unhandledRejection", (reason: any) => {
+    backendOut.appendLine(
+      `[UNHANDLED REJECTION ${new Date().toISOString()}] ${toLine(reason)}`
+    );
+  });
+  process.on("uncaughtException", (err: any) => {
+    backendOut.appendLine(
+      `[UNCAUGHT EXCEPTION ${new Date().toISOString()}] ${toLine(
+        err?.stack || err
+      )}`
+    );
+  });
 
+  _backendServer = backend();
+  console.log(
+    "Commitment Issues extension active. Thank you for installing our extension! -Noa and Joshua."
+  );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("commitment-issues.showWelcome", async () => {
-			const panel = vscode.window.createWebviewPanel(
-				"commitmentIssuesWelcome",
-				"Extension Status",
-				vscode.ViewColumn.One,
-				{}
-			);
+  const commitAnalysisProvider = new AnalysisResultsProvider(context);
+  vscode.window.registerTreeDataProvider(
+    VSCodeExtensionViews.ROOT_COMMIT_ANALYSIS_RESULTS,
+    commitAnalysisProvider
+  );
 
-			const response = await fetch("http://localhost:3066/");
-			const html = await response.text();
-			panel.webview.html = html;
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("commitment-issues.openConfig", () => {
+      vscode.commands.executeCommand(
+        "workbench.action.openSettings",
+        "Commitment Issues config"
+      );
+    })
+  );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("commitment-issues.analyzeCommits", async () => {
-			const panel = vscode.window.createWebviewPanel(
-				"commitmentIssuesAnalyze",
-				"Commit Message Analysis Results (HTML)",
-				vscode.ViewColumn.One,
-				{}
-			);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "commitment-issues.analyzeCommitMessages",
+      async () => {
+        vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: `Analyzing ${ConfigurationManager.amount} commits on ${ConfigurationManager.branch}...`,
+            cancellable: false,
+          },
+          async (progress) => {
+            await commitAnalysisProvider.analyze();
+            vscode.window.showInformationMessage("Analysis complete!");
+          }
+        );
+      }
+    )
+  );
 
-			const response = await fetch("http://localhost:3066/analyze-commits");
-			const html = await response.text();
-			panel.webview.html = html;
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "commitment-issues.showWelcome",
+      async () => {
+        const panel = vscode.window.createWebviewPanel(
+          "commitmentIssuesWelcome",
+          "Extension Status",
+          vscode.ViewColumn.One,
+          {}
+        );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("commitment-issues.analyzeCommitsJson", async () => {
-			const panel = vscode.window.createWebviewPanel(
-				"commitmentIssuesAnalyze",
-				"Commit Message Analysis Results (JSON)",
-				vscode.ViewColumn.One,
-				{}
-			);
+        const response = await fetch("http://localhost:3066/");
+        const html = await response.text();
+        panel.webview.html = html;
+      }
+    )
+  );
 
-			const response = await fetch("http://localhost:3066/analyze-commits?format=json");
-			const json = await response.json();
-			panel.webview.html = JSON.stringify(json, null, 2);
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "commitment-issues.analyzeCommits",
+      async () => {
+        const panel = vscode.window.createWebviewPanel(
+          "commitmentIssuesAnalyze",
+          "Commit Message Analysis Results (HTML)",
+          vscode.ViewColumn.One,
+          {}
+        );
+
+        const response = await fetch("http://localhost:3066/analyze-commits");
+        const html = await response.text();
+        panel.webview.html = html;
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "commitment-issues.analyzeCommitsJson",
+      async () => {
+        const panel = vscode.window.createWebviewPanel(
+          "commitmentIssuesAnalyze",
+          "Commit Message Analysis Results (JSON)",
+          vscode.ViewColumn.One,
+          {}
+        );
+
+        const response = await fetch(
+          "http://localhost:3066/analyze-commits?format=json"
+        );
+        const json = await response.json();
+        panel.webview.html = JSON.stringify(json, null, 2);
+      }
+    )
+  );
 }
 
 export function deactivate() {
-	_backendServer?.close(() => {
-		console.log("Commitment Issues server closed.");
-	});
+  _backendServer?.close(() => {
+    console.log("Commitment Issues server closed.");
+  });
 }

--- a/commitment-issues-extension/src/frontend/analysis_tree/data/analysis_results_data_provider.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/data/analysis_results_data_provider.ts
@@ -288,7 +288,7 @@ class OverallFeedbackPreviewItem extends AnalysisTreeItem {
 
 class RuleStatsRootItem extends AnalysisTreeItem {
   constructor() {
-    super("Rule Stats", vscode.TreeItemCollapsibleState.Expanded);
+    super("Rule Stats", vscode.TreeItemCollapsibleState.Collapsed);
     this.iconPath = new vscode.ThemeIcon(
       "graph",
       new vscode.ThemeColor("charts.blue")

--- a/commitment-issues-extension/src/frontend/analysis_tree/data/analysis_results_data_provider.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/data/analysis_results_data_provider.ts
@@ -1,130 +1,190 @@
-import * as vscode from 'vscode';
-import { Commit } from '../../../backend/src/models/commit';
-import { GradedCommit } from '../../../backend/src/models/graded_commit';
-import { GradedCommitDisplay } from '../../../backend/src/presentation/graded_commit_display';
-import { DefaultData } from '../../../backend/src/ai/defaultdata';
-import { AnalysisTreeItem } from '../presentation/analysis_tree_item';
-import { CommitTreeItem } from '../presentation/commit_tree_item';
-import { SuggestionTreeItem } from '../presentation/suggestion_tree_item';
-import { ViolationTreeItem } from '../presentation/violation_tree_item';
+import * as vscode from "vscode";
+import { Commit } from "../../../backend/src/models/commit";
+import { GradedCommit } from "../../../backend/src/models/graded_commit";
+import { GradedCommitDisplay } from "../../../backend/src/presentation/graded_commit_display";
+import { DefaultData } from "../../../backend/src/ai/defaultdata";
+import { AnalysisTreeItem } from "../presentation/analysis_tree_item";
+import { CommitTreeItem } from "../presentation/commit_tree_item";
+import { SuggestionTreeItem } from "../presentation/suggestion_tree_item";
+import { ViolationTreeItem } from "../presentation/violation_tree_item";
 
-export class AnalysisResultsProvider implements vscode.TreeDataProvider<AnalysisTreeItem> {
+export class AnalysisResultsProvider
+  implements vscode.TreeDataProvider<AnalysisTreeItem>
+{
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    AnalysisTreeItem | undefined | void
+  > = new vscode.EventEmitter<AnalysisTreeItem | undefined | void>();
+  readonly onDidChangeTreeData: vscode.Event<
+    AnalysisTreeItem | undefined | void
+  > = this._onDidChangeTreeData.event;
 
-	private _onDidChangeTreeData: vscode.EventEmitter<AnalysisTreeItem | undefined | void> = new vscode.EventEmitter<AnalysisTreeItem | undefined | void>();
-	readonly onDidChangeTreeData: vscode.Event<AnalysisTreeItem | undefined | void> = this._onDidChangeTreeData.event;
+  private analysisResults: GradedCommitDisplay[] = [];
+  private styleComment: string | undefined;
 
-	private analysisResults: GradedCommitDisplay[] = [];
+  constructor(private readonly context: vscode.ExtensionContext) {}
 
-	constructor(private readonly context: vscode.ExtensionContext) { }
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
 
-	refresh(): void {
-		this._onDidChangeTreeData.fire();
-	}
+  async analyze(): Promise<void> {
+    try {
+      const response = await fetch(
+        "http://localhost:3066/analyze-commits?format=json"
+      );
+      if (response.ok) {
+        const jsonData = await response.json();
+        this.analysisResults = jsonData.map(
+          (item: any) =>
+            new GradedCommitDisplay(
+              new Commit(
+                item.commit.commitHash,
+                item.commit.header,
+                item.commit.body,
+                item.commit.url,
+                item.commit.authorName,
+                item.commit.branch,
+                item.commit.repoHasOpenTasks,
+                item.commit.referencedTasks
+              ),
+              new GradedCommit(
+                item.gradedCommit.commitHash,
+                item.gradedCommit.violations,
+                item.gradedCommit.suggestion,
+                item.gradedCommit.bodySuggestion
+              )
+            )
+        );
 
-	async analyze(): Promise<void> {
-		try {
-			const response = await fetch("http://localhost:3066/analyze-commits?format=json");
-			if (response.ok) {
-				const jsonData = await response.json();
-				this.analysisResults = jsonData.map((item: any) =>
-					new GradedCommitDisplay(
-						new Commit(
-							item.commit.commitHash,
-							item.commit.header,
-							item.commit.body,
-							item.commit.url,
-							item.commit.authorName,
-							item.commit.branch,
-							item.commit.repoHasOpenTasks,
-							item.commit.referencedTasks
-						),
-						new GradedCommit(
-							item.gradedCommit.commitHash,
-							item.gradedCommit.violations,
-							item.gradedCommit.suggestion,
-							item.gradedCommit.bodySuggestion
-						)
-					)
-				);
-				this.refresh();
-			} else {
-				vscode.window.showErrorMessage("Failed to analyze commitment issues. Make sure you've configured the extension with the appropriate API keys and repository URL. You can check if the backend is running via the 'Commitment Issues: Check Extension Status' command.");
-			}
-		} catch (error) {
-			vscode.window.showErrorMessage(`Error occurred during analysis: ${error}`);
-		}
-	}
+        // short personalised style comment
+        const sc = await fetch("http://localhost:3066/style-comment");
+        if (sc.ok) {
+          const { styleComment } = await sc.json();
+          this.styleComment = styleComment;
+        } else {
+          this.styleComment = undefined;
+        }
+        this.refresh();
+      } else {
+        vscode.window.showErrorMessage(
+          "Failed to analyze commitment issues. Make sure you've configured the extension with the appropriate API keys and repository URL. You can check if the backend is running via the 'Commitment Issues: Check Extension Status' command."
+        );
+      }
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `Error occurred during analysis: ${error}`
+      );
+    }
+  }
 
-	getTreeItem(element: AnalysisTreeItem): vscode.TreeItem {
-		return element;
-	}
+  getTreeItem(element: AnalysisTreeItem): vscode.TreeItem {
+    return element;
+  }
 
-	getChildren(element?: AnalysisTreeItem): Thenable<AnalysisTreeItem[]> {
-		if (!element) {
-			return Promise.resolve(
-				this.analysisResults.map((result) => {
-					const getCollapsibleState = (gradedCommit: GradedCommit) => {
-						if (gradedCommit.grade < 5) return vscode.TreeItemCollapsibleState.Expanded;
-						if (gradedCommit.bodySuggestion || gradedCommit.suggestion) return vscode.TreeItemCollapsibleState.Expanded;
-						return vscode.TreeItemCollapsibleState.None;
-					};
-					return new CommitTreeItem(
-						this.context.extensionUri,
-						result.commit,
-						result.gradedCommit,
-						getCollapsibleState(result.gradedCommit)
-					);
-				})
-			);
-		} else if (element instanceof CommitTreeItem) {
-			const items: AnalysisTreeItem[] = [];
+  getChildren(element?: AnalysisTreeItem): Thenable<AnalysisTreeItem[]> {
+    if (!element) {
+      const rootItems: AnalysisTreeItem[] = [];
 
-			const grade = element.gradedCommit.grade;
+      // 1) personalized style comment
+      if (this.styleComment && this.styleComment.trim().length > 0) {
+        rootItems.push(
+          new SuggestionTreeItem(
+            this.context.extensionUri,
+            "Overall Style Feedback",
+            this.styleComment,
+            -1 // bez ocjene; SuggestionTreeItem će ionako prikazati opis/tooltip
+          )
+        );
+      }
 
-			if (element.gradedCommit.violations.length > 0) {
-				element.gradedCommit.violations.forEach(violation => {
-					const ruleName = DefaultData.rules.get(violation.rule) || "Unknown rule";
-					items.push(new ViolationTreeItem(this.context.extensionUri, violation.rule, ruleName));
-				});
-			}
+      // 2) existing detailed commit results
+      rootItems.push(
+        ...this.analysisResults.map((result) => {
+          const getCollapsibleState = (gradedCommit: GradedCommit) => {
+            if (gradedCommit.grade < 5)
+              return vscode.TreeItemCollapsibleState.Expanded;
+            if (gradedCommit.bodySuggestion || gradedCommit.suggestion)
+              return vscode.TreeItemCollapsibleState.Expanded;
+            return vscode.TreeItemCollapsibleState.None;
+          };
+          return new CommitTreeItem(
+            this.context.extensionUri,
+            result.commit,
+            result.gradedCommit,
+            getCollapsibleState(result.gradedCommit)
+          );
+        })
+      );
 
-			if (element.gradedCommit.suggestion) {
-				items.push(new SuggestionTreeItem(
-					this.context.extensionUri,
-					"New Header",
-					element.gradedCommit.suggestion,
-					grade
-				));
-			}
+      return Promise.resolve(rootItems);
+    }
 
-			if (element.gradedCommit.bodySuggestion) {
-				items.push(new SuggestionTreeItem(
-					this.context.extensionUri,
-					"New Body",
-					element.gradedCommit.bodySuggestion,
-					grade
-				));
-			}
+    if (element instanceof CommitTreeItem) {
+      const items: AnalysisTreeItem[] = [];
+      const grade = element.gradedCommit.grade;
 
-			return Promise.resolve(items);
-		}
+      if (element.gradedCommit.violations.length > 0) {
+        element.gradedCommit.violations.forEach((violation) => {
+          const ruleName =
+            DefaultData.rules.get(violation.rule) || "Unknown rule";
+          items.push(
+            new ViolationTreeItem(
+              this.context.extensionUri,
+              violation.rule,
+              ruleName
+            )
+          );
+        });
+      }
 
-		return Promise.resolve([]);
-	}
+      if (element.gradedCommit.suggestion) {
+        items.push(
+          new SuggestionTreeItem(
+            this.context.extensionUri,
+            "New Header",
+            element.gradedCommit.suggestion,
+            grade
+          )
+        );
+      }
 
-	public static themeColor(grade: number): vscode.ThemeColor {
-		switch (grade) {
-			case 0: return new vscode.ThemeColor("charts.red");
-			case 1: return new vscode.ThemeColor("charts.orange");
-			case 2: return new vscode.ThemeColor("charts.yellow");
-			case 3: return new vscode.ThemeColor("charts.green");
-			case 4: return new vscode.ThemeColor("charts.blue");
-			case 5: return new vscode.ThemeColor("charts.purple");
-			default: return new vscode.ThemeColor("charts.foreground");
-		}
-	}
+      if (element.gradedCommit.bodySuggestion) {
+        items.push(
+          new SuggestionTreeItem(
+            this.context.extensionUri,
+            "New Body",
+            element.gradedCommit.bodySuggestion,
+            grade
+          )
+        );
+      }
 
-	public static truncateHeader(header: string): string {
-		return header.length > 50 ? header.substring(0, 47) + "..." : header;
-	}
+      return Promise.resolve(items);
+    }
+
+    return Promise.resolve([]);
+  }
+
+  public static themeColor(grade: number): vscode.ThemeColor {
+    switch (grade) {
+      case 0:
+        return new vscode.ThemeColor("charts.red");
+      case 1:
+        return new vscode.ThemeColor("charts.orange");
+      case 2:
+        return new vscode.ThemeColor("charts.yellow");
+      case 3:
+        return new vscode.ThemeColor("charts.green");
+      case 4:
+        return new vscode.ThemeColor("charts.blue");
+      case 5:
+        return new vscode.ThemeColor("charts.purple");
+      default:
+        return new vscode.ThemeColor("charts.foreground");
+    }
+  }
+
+  public static truncateHeader(header: string): string {
+    return header.length > 50 ? header.substring(0, 47) + "..." : header;
+  }
 }

--- a/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/commit_tree_item.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/commit_tree_item.ts
@@ -1,8 +1,22 @@
 import * as vscode from 'vscode';
-import { AnalysisTreeItem } from "./analysis_tree_item";
-import { Commit } from '../../../backend/src/models/commit';
-import { GradedCommit } from '../../../backend/src/models/graded_commit';
-import { AnalysisResultsProvider } from '../data/analysis_results_data_provider';
+import { AnalysisTreeItem } from "../analysis_tree_item";
+import { Commit } from '../../../../backend/src/models/commit';
+import { GradedCommit } from '../../../../backend/src/models/graded_commit';
+import { AnalysisResultsProvider } from '../../data/analysis_results_data_provider';
+
+export class CommitsRootItem extends AnalysisTreeItem {
+  constructor(count: number) {
+    super(
+      `Detailed View by Commit (${count})`,
+      vscode.TreeItemCollapsibleState.Collapsed
+    );
+    this.iconPath = new vscode.ThemeIcon(
+      "list-tree",
+      new vscode.ThemeColor("charts.foreground")
+    );
+  }
+  contextValue = "commits-root";
+}
 
 export class CommitTreeItem extends AnalysisTreeItem {
     constructor(

--- a/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/suggestion_tree_item.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/suggestion_tree_item.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { AnalysisTreeItem } from './analysis_tree_item';
-import { AnalysisResultsProvider } from '../data/analysis_results_data_provider';
+import { AnalysisTreeItem } from '../analysis_tree_item';
+import { AnalysisResultsProvider } from '../../data/analysis_results_data_provider';
 export class SuggestionTreeItem extends AnalysisTreeItem {
 	constructor(
 		extensionRoot: vscode.Uri,

--- a/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/violation_tree_item.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/presentation/detailed_analysis_view/violation_tree_item.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { AnalysisTreeItem } from "./analysis_tree_item";
-import { AnalysisResultsProvider } from '../data/analysis_results_data_provider';
+import { AnalysisTreeItem } from "../analysis_tree_item";
+import { AnalysisResultsProvider } from '../../data/analysis_results_data_provider';
 
 export class ViolationTreeItem extends AnalysisTreeItem {
 	constructor(

--- a/commitment-issues-extension/src/frontend/analysis_tree/presentation/simple_analysis_view/overall_feedback_item.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/presentation/simple_analysis_view/overall_feedback_item.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import { AnalysisTreeItem } from "../analysis_tree_item";
+
+export class OverallFeedbackRootItem extends AnalysisTreeItem {
+  constructor() {
+    super("Overall Style Feedback", vscode.TreeItemCollapsibleState.Expanded);
+    this.iconPath = new vscode.ThemeIcon(
+      "lightbulb",
+      new vscode.ThemeColor("charts.yellow")
+    );
+    this.tooltip = "General feedback on commit-message style";
+  }
+  contextValue = "overall-style-root";
+}
+
+export class OverallFeedbackPreviewItem extends AnalysisTreeItem {
+  constructor(public readonly styleComment: string) {
+    const preview = (styleComment ?? "").length > 100
+        ? (styleComment ?? "").slice(0, 100).trim() +
+        "…"
+        : styleComment ?? "";
+    super(preview + (preview.length < styleComment.length ? " (CLICK TO VIEW FULL TEXT)" : ""), vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(
+      "quote",
+      new vscode.ThemeColor("charts.green")
+    );
+    this.tooltip = preview.length < styleComment.length
+        ? `(CLICK TO VIEW FULL TEXT) ${(preview ?? "")}` : styleComment;
+    this.command = {
+      command: "commitment-issues.showOverallFeedbackFull",
+      title: "Open Full Overall Feedback",
+    };
+  }
+  contextValue = "overall-style-preview";
+}

--- a/commitment-issues-extension/src/frontend/analysis_tree/presentation/simple_analysis_view/rule_stat_item.ts
+++ b/commitment-issues-extension/src/frontend/analysis_tree/presentation/simple_analysis_view/rule_stat_item.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { AnalysisTreeItem } from "../analysis_tree_item";
+
+export type RuleStat = { rule: number; name: string; count: number; total: number };
+
+export class RuleStatsRootItem extends AnalysisTreeItem {
+  constructor(public readonly avg: number | undefined) {
+    super("Rule Violation Stats", vscode.TreeItemCollapsibleState.Collapsed);
+    this.iconPath = new vscode.ThemeIcon(
+      "graph",
+      new vscode.ThemeColor("charts.blue")
+    );
+    this.tooltip = "Summary of violations per rule (count/total)";
+    this.description = "Average grade: ☆ " + (avg !== undefined ? avg.toPrecision(3).toString() + "/5": "N/A");
+  }
+  contextValue = "rule-stats-root";
+}
+
+export class RuleStatItem extends AnalysisTreeItem {
+  constructor(public readonly stat: RuleStat) {
+    super(
+      `Rule ${stat.rule}`,
+      vscode.TreeItemCollapsibleState.None
+    );
+    this.description = `${stat.name.split(":")[0]}: ${stat.count}/${stat.total}`;
+    this.tooltip = `Violations found in ${stat.count}/${stat.total} commit${stat.count === 1 ? "" : "s"}\n\n${stat.name}`;
+    this.iconPath = new vscode.ThemeIcon(
+      "warning",
+      new vscode.ThemeColor("charts.red")
+    );
+  }
+  contextValue = "rule-stat";
+}


### PR DESCRIPTION
Add an overall AI comment on all the commits, based on rule violations stats which are calculated from the results of the first prompt to Gemini. The overall comment is generated as a result of the second prompt to Gemini. The two prompts are chained together in a single request once the user clicks Analyze commits button.
If the average grade of all the commits is at least 4.5 and no commit is below 3, no advice is given and defaults to a placeholder message. 
The overall comment is expanded into a webview when clicked upon.
Detailed commits analysis is hidden under collapsed view on which the user can click.